### PR TITLE
Bouton retour : supprimer le label

### DIFF
--- a/routes/MainTab.js
+++ b/routes/MainTab.js
@@ -92,7 +92,7 @@ const onSharePress = async (item) => {
 
 const defaultStackOptions = {
   headerTintColor: global.isDarkMode ? 'white' : bdovored,
-  headerTruncatedBackTitle: 'Retour'
+  headerTruncatedBackTitle: ''
 };
 
 function CollectionScreens({ route, navigation }) {


### PR DESCRIPTION
Le label du bouton Retour provoque des petits bugs d'affichage sur iOS : proposition -> pas de label